### PR TITLE
Fix lambda request headers and updates to readme, python defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Terraform 0.11. Pin module version to `~> v1.0`.
 
 ## Features
 
-- [x] AWS Lambda runtime Python 3.6
+- [x] AWS Lambda runtime Python 3.9
 - [x] Create new SNS topic or use existing one
 - [ ] Support plaintext and encrypted version of Teams webhook URL
 - [ ] Most of Teams message options are customizable
@@ -37,7 +37,7 @@ Terraform 0.11. Pin module version to `~> v1.0`.
 
 ```hcl
 module "notify_teams" {
-  source  = "git::https://github.com/teamclairvoyant/terraform-aws-notify-teams.git?ref=tags/4.11.0.1"
+  source  = "git::https://github.com/teamclairvoyant/terraform-aws-notify-teams.git?ref=tags/<LATEST_TAG>"
 
   sns_topic_name = "teams-topic"
 
@@ -65,10 +65,6 @@ ENTRYPOINT ["/bin/tfc-agent"]
 
 If you want to subscribe the AWS Lambda Function created by this module to an existing SNS topic you should specify `create_sns_topic = false` as an argument and specify the name of existing SNS topic name in `sns_topic_name`.
 
-## Examples
-
-* [notify-teams-simple](https://github.com/teamclairvoyant/terraform-aws-notify-teams/tree/master/examples/notify-teams-simple) - Creates SNS topic which sends messages to Teams channel.
-* [cloudwatch-alerts-to-teams](https://github.com/teamclairvoyant/terraform-aws-notify-teams/tree/master/examples/cloudwatch-alerts-to-teams) - End to end example which shows how to send AWS Cloudwatch alerts to Teams channel and use KMS to encrypt webhook URL.
 
 ## Testing with pytest
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # AWS Notify Microsoft Teams Terraform module
 
+## Neuronostics fork
+
+This forks the upstream terraform module to add support for sending messages to a Microsoft Teams channel via an incoming webhook. The upstream module misses some appropriate `Content-Type` headers to successfully send the message. This fork adds those headers.
+
+## Original README
+
 This module creates an SNS topic (or uses an existing one) and an AWS Lambda function that sends notifications to Microsoft Teams using the [Incoming Webhook Connector](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook).
 
 Start by setting up an [incoming webhook](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook#add-an-incoming-webhook-to-a-teams-channel) in your Microsoft Teams channel.

--- a/functions/notify_teams.py
+++ b/functions/notify_teams.py
@@ -2,10 +2,10 @@
 import json
 import logging
 import os
-from urllib.error import URLError, HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-HOOK_URL = os.environ['TEAMS_WEBHOOK_URL']
+HOOK_URL = os.environ["TEAMS_WEBHOOK_URL"]
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -13,68 +13,73 @@ logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
     logger.info("Event: " + str(event))
-    message = event['Records'][0]['Sns']['Message']
+    message = event["Records"][0]["Sns"]["Message"]
     data = ""
     if is_cloudwatch_alarm(message):
-        message_json = json.loads(event['Records'][0]['Sns']['Message'])
-        alarm_name = message_json['AlarmName']
-        old_state = message_json['OldStateValue']
-        new_state = message_json['NewStateValue']
-        reason = message_json['NewStateReason']
+        message_json = json.loads(event["Records"][0]["Sns"]["Message"])
+        alarm_name = message_json["AlarmName"]
+        old_state = message_json["OldStateValue"]
+        new_state = message_json["NewStateValue"]
+        reason = message_json["NewStateReason"]
         logger.info("Message: " + str(message_json))
 
         base_data = {
-          "colour": "64a837",
-          "title": "**%s** is resolved" % alarm_name,
-          "text": "**%s** has changed from %s to %s - %s" % (
-            alarm_name, old_state, new_state, reason)
+            "colour": "64a837",
+            "title": "**%s** is resolved" % alarm_name,
+            "text": "**%s** has changed from %s to %s - %s"
+            % (alarm_name, old_state, new_state, reason),
         }
-        if new_state.lower() == 'alarm':
+        if new_state.lower() == "alarm":
             base_data = {
-              "colour": "d63333",
-              "title": "Red Alert - There is an issue %s" % alarm_name,
-              "text": "**%s** has changed from %s to %s - %s" % (
-                alarm_name, old_state, new_state, reason)
+                "colour": "d63333",
+                "title": "Red Alert - There is an issue %s" % alarm_name,
+                "text": "**%s** has changed from %s to %s - %s"
+                % (alarm_name, old_state, new_state, reason),
             }
 
         messages = {
-          ('ALARM', 'my-alarm-name'): {
-            "colour": "d63333",
-            "title": "Red Alert - A bad thing happened.",
-            "text": "These are the specific details of the bad thing."
-          },
-          ('OK', 'my-alarm-name'): {
-            "colour": "64a837",
-            "title": "The bad thing stopped happening",
-            "text": "These are the specific details of how we know the bad "
-                    "thing stopped happening "
-          }
+            ("ALARM", "my-alarm-name"): {
+                "colour": "d63333",
+                "title": "Red Alert - A bad thing happened.",
+                "text": "These are the specific details of the bad thing.",
+            },
+            ("OK", "my-alarm-name"): {
+                "colour": "64a837",
+                "title": "The bad thing stopped happening",
+                "text": "These are the specific details of how we know the bad "
+                "thing stopped happening ",
+            },
         }
         data = messages.get((new_state, alarm_name), base_data)
     else:
         data = {
-          "colour": "d63333",
-          "title": "Alert - There is an issue: %s" % event['Records'][0]['Sns']
-          ['Subject'],
-          "text": json.dumps({
-            "Subject": event['Records'][0]['Sns']['Subject'],
-            "Type": event['Records'][0]['Sns']['Type'],
-            "MessageId": event['Records'][0]['Sns']['MessageId'],
-            "TopicArn": event['Records'][0]['Sns']['TopicArn'],
-            "Message": event['Records'][0]['Sns']['Message'],
-            "Timestamp": event['Records'][0]['Sns']['Timestamp']
-          })
+            "colour": "d63333",
+            "title": "Alert - There is an issue: %s"
+            % event["Records"][0]["Sns"]["Subject"],
+            "text": json.dumps(
+                {
+                    "Subject": event["Records"][0]["Sns"]["Subject"],
+                    "Type": event["Records"][0]["Sns"]["Type"],
+                    "MessageId": event["Records"][0]["Sns"]["MessageId"],
+                    "TopicArn": event["Records"][0]["Sns"]["TopicArn"],
+                    "Message": event["Records"][0]["Sns"]["Message"],
+                    "Timestamp": event["Records"][0]["Sns"]["Timestamp"],
+                }
+            ),
         }
 
     message = {
-      "@context": "https://schema.org/extensions",
-      "@type": "MessageCard",
-      "themeColor": data["colour"],
-      "title": data["title"],
-      "text": data["text"]
+        "@context": "https://schema.org/extensions",
+        "@type": "MessageCard",
+        "themeColor": data["colour"],
+        "title": data["title"],
+        "text": data["text"],
     }
 
-    req = Request(HOOK_URL, json.dumps(message).encode('utf-8'))
+    req = Request(HOOK_URL, json.dumps(message).encode("utf-8"))
+    # add content-type json header
+    req.add_header("Content-Type", "application/json; charset=utf-8")
+
     try:
         response = urlopen(req)
         response.read()
@@ -88,7 +93,7 @@ def lambda_handler(event, context):
 def is_cloudwatch_alarm(message):
     try:
         message_json = json.loads(message)
-        if message_json['AlarmName']:
+        if message_json["AlarmName"]:
             return True
         else:
             return False

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "create_sns_topic" {
 variable "python_version" {
   description = "Python version for lambda"
   type        = string
-  default     = "3.9"
+  default     = "python3.9"
 }
 
 variable "lambda_role" {


### PR DESCRIPTION
## Description

The `incoming webhook` expects a `content-type` header of `application/json` to parse the JSON message correctly. I've tested this in postman and by modifying the lambda, but this just makes the change here so we can be consistent in terraform. 

There's also some minor readme changes to remove legacy stuff. If we like, we can try and open a pull request with this change against the upstream.