### PR TITLE
fix: typo with color causing crash when initiated

### DIFF
--- a/functions/notify_teams.py
+++ b/functions/notify_teams.py
@@ -37,7 +37,7 @@ def lambda_handler(event, context):
     message = {
         "@context": "https://schema.org/extensions",
         "@type": "MessageCard",
-        "themeColor": data["colour"],
+        "themeColor": data["color"],
         "title": data["title"],
         "text": alarm_description + "\n" + data["text"],
     }


### PR DESCRIPTION
This was causing a crash as per AWS when trying to run, as there was inconsistencies with the spelling of color. Make all the instances US-english for consistency (sadly 🇬🇧 )

![Screenshot 2024-04-10 at 13 39 44](https://github.com/neuronostics/terraform-aws-notify-teams/assets/9056334/ee278b28-9370-4402-8956-d6d1efeb780e)
